### PR TITLE
revert process to use with old checkpoint

### DIFF
--- a/ml/util/process.py
+++ b/ml/util/process.py
@@ -3,22 +3,28 @@ import numpy as np
 import torch
 from torchvision import datasets, transforms
 
-IMAGENET_MEAN = [0.485, 0.456, 0.406]
-IMAGENET_STD = [0.229, 0.224, 0.225]
+IMAGENET_MEAN = (0.485, 0.456, 0.406)
+IMAGENET_STD = (0.229, 0.224, 0.225)
+
+DEFAULT_MEAN = (0.5, 0.5, 0.5)
+DEFAULT_STD = (0.5, 0.5, 0.5)
 
  # downsize image res to 256, crop the center 224, and grayscale
-PREPROCESS_TRANSFORM = transforms.Compose([transforms.Resize([256, 256]),
+PREPROCESS_TRANSFORM = transforms.Compose([
+    transforms.Resize((244,244)),
     transforms.CenterCrop(224),
     transforms.ToTensor(),
-    transforms.Normalize(IMAGENET_MEAN, IMAGENET_STD)])
+    transforms.Normalize(IMAGENET_MEAN, IMAGENET_STD)
+])
 
 # preprocess and rotate and flip images for more data
-DATA_AUGMENT_TRANSFORM = transforms.Compose([transforms.Resize([256, 256]),
+DATA_AUGMENT_TRANSFORM = transforms.Compose([
+    transforms.Resize((244,244)),
     transforms.RandomRotation(30),
     transforms.RandomHorizontalFlip(),
-    transforms.CenterCrop(224),
     transforms.ToTensor(),
-    transforms.Normalize(IMAGENET_MEAN, IMAGENET_STD)])
+    transforms.Normalize(DEFAULT_MEAN, DEFAULT_STD)
+])
 
 # process the image in the same way as our training data
 def process_image(image_path):


### PR DESCRIPTION
# Why is this Pull Request required
- `process.py` was changed so the preprocess is different than the one used for the checkpoint currently in master
- to keep consistency, we should only update the preprocess when we update the checkpoint

# Changes
- revert `process.py` back to have the original preprocess transform