### PR TITLE
add error page and catch errors on image processing

### DIFF
--- a/finder/templates/error.html
+++ b/finder/templates/error.html
@@ -1,0 +1,65 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="description" content="">
+  <meta name="author" content="">
+
+  <title>FindCar</title>
+
+  <!-- Bootstrap CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+  <!-- Custom styles for this template -->
+  <link rel="stylesheet" href="{% static 'css/style.css' %}">
+
+</head>
+
+<body>
+
+  <!-- Navigation -->
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+    <div class="container">
+      <a class="navbar-brand" href="/">FindCar</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarResponsive">
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-item">
+            <a class="nav-link" href="/">Home
+              <!-- <span class="sr-only">(current)</span> -->
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/upload">Upload Image
+              <span class="sr-only">(current)</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Header -->
+  <header class="bg-primary py-5 mb-5">
+  </header>
+
+<center>
+  <h1>
+    Oops, there was an error
+  </h1>
+  <hr>
+  <p>
+    {{errorMessage}}
+  </p>
+  <br>
+  <a class="nav-link" href="/upload">Back to Upload</a>
+  <a class="nav-link" href="/">Back to Home</a>
+</center>
+
+</body>
+</html>

--- a/finder/templates/upload.html
+++ b/finder/templates/upload.html
@@ -55,7 +55,12 @@
   <form method="post" enctype="multipart/form-data" action="predictImage">
 
 {% csrf_token %}
-<div class = "col-md-4 col-sm-4"><label for="fname"></label> </div><input name = "filePath" type = "file" ><br><br>
+<div class = "col-md-4 col-sm-4">
+  <label for="fname"></label>
+</div>
+<input name="filePath" type="file" accept="image/*;capture=camera" />
+<br>
+<br>
 <br>
 
 

--- a/finder/views.py
+++ b/finder/views.py
@@ -33,7 +33,14 @@ class Index(View):
         full_image_path = os.path.join('finder', 'static', 'media', image_name)
 
         # get prediction
-        pred_confs, pred_classes = self._predictor.predict(full_image_path)
+        try:
+            pred_confs, pred_classes = self._predictor.predict(full_image_path)
+        except:
+            context = {
+                'errorMessage': 'There was an error processing your image. Make sure it is not a corrupted image file.'
+            }
+            return render(request, 'error.html', context)
+        
         predicted_class = self._classes[pred_classes[0]]
         
         # plot confidence scores
@@ -51,5 +58,4 @@ class Index(View):
             'plotImagePath': f'/{plot_image_path}',
             'submitted': submitted
         }
-        return render(request,'upload.html',context)
-
+        return render(request, 'upload.html', context)


### PR DESCRIPTION
# Changes
- add an error page that displays a message and has buttons to go home or to upload
- add an error catch for image processing (if, for example, they upload something that is not an image or is corrupted)
- changed the input tag in `upload.html` to maybe accept camera images on mobile. not tested yet